### PR TITLE
fix: "refresh token validation"

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,6 +8,7 @@ import {
   Req,
   Delete,
   Put,
+  Headers,
 } from '@nestjs/common';
 import {
   ApiConsumes,
@@ -53,7 +54,7 @@ export class AuthController {
   @ApiResponse({ status: 201, description: '회원가입 성공' })
   @ApiOperation({
     summary: '로그인',
-    description: 'AccessToken && RefreshToken반환\n각 유효기간 2h, 2w',
+    description: 'AccessToken && RefreshToken반환\n각 유효기간 1h, 2w',
   })
   async login(@Body() body: LoginDto) {
     return await this.authService.login(body);
@@ -68,7 +69,7 @@ export class AuthController {
     summary: '회원탈퇴',
   })
   async deleteUser(@Req() req) {
-    return await this.authService.deleteUser(req.id);
+    return await this.authService.deleteUser(req.user.id);
   }
 
   @UseGuards(AuthGuard('refresh'))
@@ -78,7 +79,13 @@ export class AuthController {
   @ApiOperation({
     summary: 'Access Token 재발급',
   })
+  //header 값 가져오는 데코레이터
+  //header에 authorization 필드가 인증 정보를 가지고 있음.
   restoreAccessToken(@Req() req) {
-    return this.authService.newAccessToken(req.id);
+    return this.authService.newAccessToken(
+      //passport 인증은 jwt에서 추출한 정보를 user 속성에 담는다!!!
+      req.user.id,
+      req.headers.authorization.substring(7),
+    );
   }
 }

--- a/src/auth/strategies/jwt-refresh.ts
+++ b/src/auth/strategies/jwt-refresh.ts
@@ -8,6 +8,7 @@ export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'refresh') {
       secretOrKey: process.env.SECRET_KEY_REFRESH,
     });
   }
+
   validate(payload) {
     console.log(payload);
     return {

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -11,6 +11,7 @@ export class UserRepository extends Repository<User> {
   }
 
   async findUserById(id: number): Promise<User> {
+    //id가 null인 경우도 쿼리가 실행됨.!!
     const user = await this.findOne({ where: { id: id } });
     return user;
   }
@@ -22,6 +23,7 @@ export class UserRepository extends Repository<User> {
 
   async saveJwtRefresh(loginDto: LoginDto, jwtRefresh: string) {
     const user = await this.findUserByLoginId(loginDto.loginId);
+    console.log(user);
     user.jwtRefresh = jwtRefresh;
     await this.save(user);
   }


### PR DESCRIPTION
로그인 할 때마다 refresh token이 재발급 되고,
bcrypt암호화해서 db에 저장해 놓아서,
refresh token을 이용해 access token을 재발급 받으려 할 시,
유효기간이 남아 있더라도 db에 저장된 refresh token과 같지 않으면
access token 재발급 안함.

효과:
1. 다중 로그인 방지 -> access token 여러곳에서 동시에 재발급 못받음.
2. refresh token 탈취 되어도 access token 계속 발급 못 받도록.